### PR TITLE
Fix backward pass bugs, add fp16 support, add product-max

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ c2 = (a + b).logsumexp(-2)
 # Grad
 sample_a, sample_b = torch.autograd.grad(c.sum(), (a, b))
 # c2 = (a + b).softmax(-2).sample(-2)
+
+# Product-Max
+c = genbmm.prodmaxbmm(a, b)
+# Equivalent
+a = a.unsqueeze(-1)
+b = b.unsqueeze(-3)
+c2, = (a * b).max(-2)
+# Grad
+grad_a, grad_b = torch.autograd.grad(c.sum(), (a, b))
 ```
 
 ### Banded Sparse Matrices

--- a/banded_cuda_kernel.cu
+++ b/banded_cuda_kernel.cu
@@ -386,7 +386,7 @@ std::vector<torch::Tensor> banded_cuda_forward(
             .device(torch::kCUDA, a.device().index());
     auto indices = torch::zeros({batch_size, a_size, new_size}, options2);
 
-    AT_DISPATCH_FLOATING_TYPES(a.type(), "banded_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "banded_forward_cuda", ([&] {
                 banded_cuda_forward_kernel_mul<scalar_t><<<blocks, threads_per_block>>>(
                     a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                     b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -432,7 +432,7 @@ std::vector<torch::Tensor> banded_cuda_backward(
     const dim3 threads_per_block(threads, threads, 1);
     auto grad_a = torch::zeros_like(a);
 
-    AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
        banded_cuda_backward_kernel_mul<scalar_t><<<blocks, threads_per_block>>>(
            grad_a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
            a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -481,7 +481,7 @@ std::vector<torch::Tensor> banded_cuda_backbackward(
     const dim3 threads_per_block(threads, threads, 1);
 
 
-    AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
        banded_cuda_backbackward_kernel_A<scalar_t><<<blocks, threads_per_block>>>(
            grad_a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
            a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -505,7 +505,7 @@ std::vector<torch::Tensor> banded_cuda_backbackward(
     const dim3 threads_per_block(threads, threads, 1);
 
 
-    AT_DISPATCH_FLOATING_TYPES(b.type(), "matmul_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(b.type(), "matmul_forward_cuda", ([&] {
        banded_cuda_backbackward_kernel_B<scalar_t><<<blocks, threads_per_block>>>(
            grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
            a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -527,7 +527,7 @@ std::vector<torch::Tensor> banded_cuda_backbackward(
                       batch_size);
     const dim3 threads_per_block(threads, threads, 1);
 
-    AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
        banded_cuda_backbackward_kernel_C<scalar_t><<<blocks, threads_per_block>>>(
            grad_grad.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
            a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),

--- a/genbmm/__init__.py
+++ b/genbmm/__init__.py
@@ -1,4 +1,4 @@
-from .genmul import logbmm, samplebmm, maxbmm
+from .genmul import logbmm, samplebmm, maxbmm, prodmaxbmm
 from .sparse import BandedMatrix, banddiag
 
-__all__ = [logbmm, samplebmm, maxbmm, BandedMatrix, banddiag]
+__all__ = [logbmm, samplebmm, maxbmm, prodmaxbmm, BandedMatrix, banddiag]

--- a/genbmm/genmul.py
+++ b/genbmm/genmul.py
@@ -60,9 +60,9 @@ class MaxMatMul(torch.autograd.Function):
     def backward(ctx, grad_output):
         a, b, switches = ctx.saved_tensors
         grad_a, grad_b = _genbmm.backward(
-            a, b, grad_output.contiguous(), switches.to(a.dtype), switches.to(a.dtype), 1
+            a.float(), b.float(), grad_output.contiguous().float(), switches.float(), switches.float(), 1
         )
-        return grad_a, grad_b
+        return grad_a.to(a.dtype), grad_b.to(b.dtype)
 
 
 class SampleMatMul(torch.autograd.Function):

--- a/genbmm/genmul.py
+++ b/genbmm/genmul.py
@@ -12,7 +12,7 @@ class LogMatMulBack(torch.autograd.Function):
     @staticmethod
     def forward(ctx, a, b, grad_out, part, maxes):
         ctx.save_for_backward(a, b, grad_out, part, maxes)
-        grad_a, = _genbmm.backward(a, b, grad_out, part, maxes, 0)
+        grad_a, _ = _genbmm.backward(a, b, grad_out, part, maxes, 0)
         return grad_a
 
     @staticmethod
@@ -76,9 +76,9 @@ class SampleMatMul(torch.autograd.Function):
     def backward(ctx, grad_output):
         a, b, switches = ctx.saved_tensors
         grad_a, grad_b = _genbmm.backward(
-            a, b, grad_output.contiguous(), switches.float(), 2
+            a.float(), b.float(), grad_output.contiguous().float(), switches.float(), switches.float(), 2
         )
-        return grad_a, grad_b
+        return grad_a.to(a.dtype), grad_b.to(b.dtype)
 
 
 logbmm = LogMatMul.apply

--- a/genbmm/genmul.py
+++ b/genbmm/genmul.py
@@ -60,7 +60,7 @@ class MaxMatMul(torch.autograd.Function):
     def backward(ctx, grad_output):
         a, b, switches = ctx.saved_tensors
         grad_a, grad_b = _genbmm.backward(
-            a, b, grad_output.contiguous(), switches.float(), 1
+            a, b, grad_output.contiguous(), switches.to(a.dtype), switches.to(a.dtype), 1
         )
         return grad_a, grad_b
 

--- a/genbmm/genmul.py
+++ b/genbmm/genmul.py
@@ -81,6 +81,23 @@ class SampleMatMul(torch.autograd.Function):
         return grad_a.to(a.dtype), grad_b.to(b.dtype)
 
 
+class ProdMaxMatMul(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, a, b):
+        out, switches = _genbmm.forward(a, b, 3)
+        ctx.save_for_backward(a, b, switches)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        a, b, switches = ctx.saved_tensors
+        grad_a, grad_b = _genbmm.backward(
+            a.float(), b.float(), grad_output.contiguous().float(), switches.float(), switches.float(), 3
+        )
+        return grad_a.to(a.dtype), grad_b.to(b.dtype)
+
+
 logbmm = LogMatMul.apply
 maxbmm = MaxMatMul.apply
 samplebmm = SampleMatMul.apply
+prodmaxbmm = ProdMaxMatMul.apply

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -539,7 +539,7 @@ std::vector<torch::Tensor> matmul_cuda_forward(
                       in_size, a_size, b_size);
               } ) );
       return {out, indices};
-
+  }
 }
 
 

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -323,7 +323,7 @@ __global__ void max_cuda_backward_kernel_A(
       for (int k = 0; k < b_size; ++k) {
           /* scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.0; */
           /* val += v * grad_output[n][row][k]; */
-          if (col == part[n][row][k] {
+          if (col == part[n][row][k]) {
               val += b[n][col][k] * grad_output[n][row][k];
           }
       }

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -321,8 +321,11 @@ __global__ void max_cuda_backward_kernel_A(
   if (row < a_size && col < in_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < b_size; ++k) {
-          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.0;
-          val += v * grad_output[n][row][k];
+          /* scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.0; */
+          /* val += v * grad_output[n][row][k]; */
+          if (col == part[n][row][k] {
+              val += b[n][col][k] * grad_output[n][row][k];
+          }
       }
       grad_a[n][row][col] = val;
   }

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -63,7 +63,7 @@ __global__ void max_cuda_forward_kernel(
   int ind = -1;
   if (row < a_size && col < b_size) {
       for (int i = 0; i < in_size; ++i) {
-         scalar_t v = a[n][row][i] + b[n][i][col];
+         scalar_t v = a[n][row][i] * b[n][i][col];
          if (v > m) {
              m = v;
              ind = i;
@@ -321,7 +321,7 @@ __global__ void max_cuda_backward_kernel_A(
   if (row < a_size && col < in_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < b_size; ++k) {
-          scalar_t v = (col == part[n][row][k]) ? 1 : 0;
+          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0;
           val += v * grad_output[n][row][k];
       }
       grad_a[n][row][col] = val;
@@ -350,7 +350,7 @@ __global__ void max_cuda_backward_kernel_B(
   if (row < in_size && col < b_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < a_size; ++k) {
-          scalar_t v = (row == part[n][k][col]) ? 1 : 0;
+          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0;
           val += v * grad_output[n][k][col];
       }
       grad_b[n][row][col] = val;

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -321,7 +321,7 @@ __global__ void max_cuda_backward_kernel_A(
   if (row < a_size && col < in_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < b_size; ++k) {
-          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0;
+          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.;
           val += v * grad_output[n][row][k];
       }
       grad_a[n][row][col] = val;
@@ -350,7 +350,7 @@ __global__ void max_cuda_backward_kernel_B(
   if (row < in_size && col < b_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < a_size; ++k) {
-          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0;
+          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.;
           val += v * grad_output[n][k][col];
       }
       grad_b[n][row][col] = val;

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -575,15 +575,15 @@ std::vector<torch::Tensor> matmul_cuda_backward(
                       in_size, a_size, b_size);
               }));
 
-      /* AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] { */
-      /*             max_cuda_backward_kernel_B<scalar_t><<<blocks2, threads_per_block>>>( */
-      /*                 grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
-      /*                 a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
-      /*                 b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
-      /*                 part.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
-      /*                 grad_out.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
-      /*                 in_size, a_size, b_size); */
-      /*         })); */
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
+                  max_cuda_backward_kernel_B<scalar_t><<<blocks2, threads_per_block>>>(
+                      grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                      a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                      b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                      part.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                      grad_out.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                      in_size, a_size, b_size);
+              }));
   }
-  return {grad_a};
+  return {grad_a, grad_b};
 }

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -321,7 +321,7 @@ __global__ void max_cuda_backward_kernel_A(
   if (row < a_size && col < in_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < b_size; ++k) {
-          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.;
+          scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.0;
           val += v * grad_output[n][row][k];
       }
       grad_a[n][row][col] = val;
@@ -350,7 +350,7 @@ __global__ void max_cuda_backward_kernel_B(
   if (row < in_size && col < b_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < a_size; ++k) {
-          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.;
+          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.0;
           val += v * grad_output[n][k][col];
       }
       grad_b[n][row][col] = val;

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -389,7 +389,7 @@ std::vector<torch::Tensor> matmul_cuda_forward(
   // Dispatch
   if (mode == 0) {
       auto maxes = torch::zeros({batch_size, a_size, b_size}, options);
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
                   matmul_cuda_forward_kernel<scalar_t><<<blocks, threads_per_block>>>(
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -403,7 +403,7 @@ std::vector<torch::Tensor> matmul_cuda_forward(
               .dtype(torch::kInt)
               .device(torch::kCUDA, a.device().index());
       auto indices = torch::zeros({batch_size, a_size, b_size}, options2);
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
                   max_cuda_forward_kernel<scalar_t><<<blocks, threads_per_block>>>(
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -418,7 +418,7 @@ std::vector<torch::Tensor> matmul_cuda_forward(
               .device(torch::kCUDA, a.device().index());
       auto indices = torch::zeros({batch_size, a_size, b_size}, options2);
       auto rand = torch::rand({batch_size, a_size, b_size}, options);
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
                   sample_cuda_forward_kernel<scalar_t><<<blocks, threads_per_block>>>(
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -471,7 +471,7 @@ std::vector<torch::Tensor> matmul_cuda_backbackward(
                      batch_size);
 
   if (mode == 0) {
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_backbackward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_backbackward_cuda", ([&] {
                   matmul_cuda_backbackward_kernel_A<scalar_t><<<blocks, threads_per_block>>>(
                       grad_a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -483,7 +483,7 @@ std::vector<torch::Tensor> matmul_cuda_backbackward(
                       in_size, a_size, b_size
                                                                                          );
               }));
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_backbackward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_backbackward_cuda", ([&] {
                   matmul_cuda_backbackward_kernel_B<scalar_t><<<blocks2, threads_per_block>>>(
                       grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -495,7 +495,7 @@ std::vector<torch::Tensor> matmul_cuda_backbackward(
                       in_size, a_size, b_size
                                                                                          );
               }));
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_backbackward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_backbackward_cuda", ([&] {
                   matmul_cuda_backbackward_kernel_C<scalar_t><<<blocks3, threads_per_block>>>(
                       grad_grad.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -541,7 +541,7 @@ std::vector<torch::Tensor> matmul_cuda_backward(
                     batch_size);
 
   if (mode == 0) {
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
                   matmul_cuda_backward_kernel_A<scalar_t><<<blocks, threads_per_block>>>(
                       grad_a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -553,7 +553,7 @@ std::vector<torch::Tensor> matmul_cuda_backward(
                                                                                          );
               }));
 
-      /* AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] { */
+      /* AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] { */
       /*             matmul_cuda_backward_kernel_B<scalar_t><<<blocks2, threads_per_block>>>( */
       /*                 grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
       /*                 a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
@@ -565,7 +565,7 @@ std::vector<torch::Tensor> matmul_cuda_backward(
       /*         })); */
   } else if (mode == 1 or mode == 2) {
 
-      AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] {
                   max_cuda_backward_kernel_A<scalar_t><<<blocks, threads_per_block>>>(
                       grad_a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                       a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
@@ -575,7 +575,7 @@ std::vector<torch::Tensor> matmul_cuda_backward(
                       in_size, a_size, b_size);
               }));
 
-      /* AT_DISPATCH_FLOATING_TYPES(a.type(), "matmul_forward_cuda", ([&] { */
+      /* AT_DISPATCH_FLOATING_TYPES_AND_HALF(a.type(), "matmul_forward_cuda", ([&] { */
       /*             max_cuda_backward_kernel_B<scalar_t><<<blocks2, threads_per_block>>>( */
       /*                 grad_b.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */
       /*                 a.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(), */

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -63,7 +63,7 @@ __global__ void max_cuda_forward_kernel(
   int ind = -1;
   if (row < a_size && col < b_size) {
       for (int i = 0; i < in_size; ++i) {
-         scalar_t v = a[n][row][i] * b[n][i][col];
+         scalar_t v = a[n][row][i] + b[n][i][col];
          if (v > m) {
              m = v;
              ind = i;
@@ -355,7 +355,7 @@ __global__ void max_cuda_backward_kernel_A(
           /* scalar_t v = (col == part[n][row][k]) ? b[n][col][k] : 0.0; */
           /* val += v * grad_output[n][row][k]; */
           if (col == part[n][row][k]) {
-              val += b[n][col][k] * grad_output[n][row][k];
+              val += grad_output[n][row][k];
           }
       }
       grad_a[n][row][col] = val;
@@ -387,7 +387,7 @@ __global__ void max_cuda_backward_kernel_B(
           /* scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.0; */
           /* val += v * grad_output[n][k][col]; */
           if (row == part[n][k][col]) {
-              val += a[n][k][row] * grad_output[n][k][col];
+              val += grad_output[n][k][col];
           }
       }
       grad_b[n][row][col] = val;

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -350,8 +350,11 @@ __global__ void max_cuda_backward_kernel_B(
   if (row < in_size && col < b_size) {
       scalar_t val = 0.0;
       for (int k = 0; k < a_size; ++k) {
-          scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.0;
-          val += v * grad_output[n][k][col];
+          /* scalar_t v = (row == part[n][k][col]) ? a[n][k][row] : 0.0; */
+          /* val += v * grad_output[n][k][col]; */
+          if (row == part[n][k][col]) {
+              val += a[n][k][row] * grad_output[n][k][col];
+          }
       }
       grad_b[n][row][col] = val;
   }

--- a/matmul_cuda_kernel.cu
+++ b/matmul_cuda_kernel.cu
@@ -457,7 +457,7 @@ std::vector<torch::Tensor> matmul_cuda_backbackward(
 
 
   auto grad_b = torch::zeros_like(b);
-  auto grad_bp = grad_b.packed_accessor32<float,3,torch::RestrictPtrTraits>();
+  /* auto grad_bp = grad_b.packed_accessor32<float,3,torch::RestrictPtrTraits>(); */
   const int threads2 = 32;
   const dim3 blocks2(in_size / threads2 + 1,
                     b_size / threads2 + 1,
@@ -534,7 +534,7 @@ std::vector<torch::Tensor> matmul_cuda_backward(
 
 
   auto grad_b = torch::zeros_like(b);
-  auto grad_bp = grad_b.packed_accessor32<float,3,torch::RestrictPtrTraits>();
+  /* auto grad_bp = grad_b.packed_accessor32<float,3,torch::RestrictPtrTraits>(); */
   const int threads2 = 32;
   const dim3 blocks2(in_size / threads2 + 1,
                     b_size / threads2 + 1,


### PR DESCRIPTION
This pull request makes the following changes:
  - It fixes a backward pass bug due to a mismatch of function inputs and outputs
  - It adds fp16 support
  - It adds a new generalized bmm operation, `prodmaxbmm`, where `out[n, i, j] = max_k a[n, i, k] * b[n, k, j]`